### PR TITLE
Add an option "predocmark" for anticipated doc.

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -81,7 +81,7 @@ def main():
                u'google_plus',u'linkedin',u'email',u'website',u'project_github',
                u'project_bitbucket',u'project_website',u'project_download',
                u'project_sourceforge',u'project_url',u'display',u'version',
-               u'year',u'docmark',u'media_dir',u'favicon']
+               u'year',u'docmark',u'predocmark',u'media_dir',u'favicon']
     defaults = {u'project_dir':       u'./src',
                 u'extensions':        [u"f90",u"f95",u"f03",u"f08"],
                 u'output_dir':        u'./doc',
@@ -91,6 +91,7 @@ def main():
                 u'year':              date.today().year,
                 u'exclude':           [],
                 u'docmark':           '!',
+                u'predocmark':        '',
                 u'favicon':           'default-icon',
                }
     
@@ -124,7 +125,8 @@ def main():
     # Parse the files in your project
     project = ford.fortran_project.Project(proj_data['project'],
                 proj_data['project_dir'], proj_data['extensions'], 
-                proj_data['display'], proj_data['exclude'], proj_data['docmark'])
+                proj_data['display'], proj_data['exclude'], 
+                proj_data['docmark'], proj_data['predocmark'])
     if len(project.files) < 1:
         print "Error: No source files with appropriate extension found in specified directory."
         quit()

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -36,7 +36,8 @@ class Project(object):
     project which is to be documented.
     """
     def __init__(self,name,topdir=".",extensions=["f90","f95","f03","f08"],
-                 display=['public','protected'], exclude=[],docmark='!'):
+                 display=['public','protected'], exclude=[], 
+                 docmark='!', predocmark=''):
         self.name = name
         self.topdir = topdir
         self.extensions = extensions
@@ -47,7 +48,7 @@ class Project(object):
         self.types = []
         self.display = display
         
-        ford.sourceform.set_doc_mark(docmark)
+        ford.sourceform.set_doc_mark(docmark,predocmark)
         
         # Get all files within topdir, recursively
         srctree = os.walk(topdir)

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -49,6 +49,7 @@ PARA_CAPTURE_RE = re.compile("<p>.*?</p>",re.IGNORECASE|re.DOTALL)
 
 base_url = ''
 docmark = '!'
+predocmark = ''
 
 #TODO: Add ability to note EXTERNAL procedures, PARAMETER statements, and DATA statements.
 class FortranBase(object):
@@ -429,7 +430,7 @@ class FortranSourceFile(FortranContainer):
         self.doc = []
         self.hierarchy = []
         self.obj = 'sourcefile'
-        source = ford.reader.FortranReader(self.path,docmark)
+        source = ford.reader.FortranReader(self.path,docmark,predocmark)
         FortranContainer.__init__(self,source,"")
         readobj = open(self.path,'r')
         self.src = readobj.read()
@@ -1074,9 +1075,11 @@ def parse_type(string,capture_strings):
 def set_base_url(url):
     FortranBase.base_url = url
 
-def set_doc_mark(mark):
+def set_doc_mark(mark,premark):
     global docmark
     docmark = mark
+    global predocmark
+    predocmark = premark
 
 def get_mod_procs(source,line,parent):
     inherit_permission = parent.permission


### PR DESCRIPTION
predocmark defaults to '' which does not recognize any anticipated
documentation. Setting it to '>' allows, for instance, documenting the
code as

!> Some documentation
!! for the varibale i
integer :: i