### PR TITLE
Sort page files and directories alphabetically. Fixes #121

### DIFF
--- a/ford/pagetree.py
+++ b/ford/pagetree.py
@@ -89,7 +89,7 @@ class PageNode(object):
     
 def get_page_tree(topdir,md,parent=None):
     # look for files within topdir
-    filelist = os.listdir(topdir)
+    filelist = sorted(os.listdir(topdir))
     if 'index.md' in filelist:
         # process index.md
         try:


### PR DESCRIPTION
This simple change allows you to specify the order by which the pages appear by changing the names of the file and directories. 

For example,  the following directory structure 
```
page_dir
├── index.md (README)
├── 01_changelog.md (ChangeLog)
├── 02_equations.md (Fluid Equations)
├── 03_examples
|   ├── index.md (Example Simulations)
|   ├── 02_shock.md (1D shock tube)
|   └── 01_collapse.md (Collapsing gas cloud)
└── 04_todo.md (ToDo)
```

will produce the following page heirarchy
```
README
├── ChangeLog
├── Fluid Equations
├── Example Simulations
|   ├── Collapsing gas cloud
|   └── 1D shock tube
└── ToDo
```