### PR TITLE
Allow rendering of MathJax in HTTP aswell as HTTPS connections.

### DIFF
--- a/ford/templates/base.html
+++ b/ford/templates/base.html
@@ -133,6 +133,6 @@
         }
       });
     </script>
-    <script src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   </body>
 </html>


### PR DESCRIPTION
Using a protocol-relative address for the script as described in the [MathJax docu](http://docs.mathjax.org/en/latest/start.html#secure-access-to-the-cdn), would allow the LaTeX rendering to work for both protocols.