### PR TITLE
Fix ford not to exit silently when encountering deep paths.

### DIFF
--- a/ford/utils.py
+++ b/ford/utils.py
@@ -146,7 +146,10 @@ def split_path(path):
     a list.
     '''
     def recurse_path(path,retlist):
-        if len(retlist) > 10: exit(0)
+        if len(retlist) > 100:
+            fullpath = os.path.join(*([ path, ] + retlist))
+            print("Directory '{}' contains too many levels".format(fullpath))
+            exit(1)
         head, tail = os.path.split(path)
         if len(tail) > 0:
             retlist.insert(0,tail)


### PR DESCRIPTION
It can be very puzzling for a user to find out, why Ford does not produce any output or error messages, when the current directory is deeper than ten levels (took me about an hour to realize...) Patch below would set the allowed depth higher and create a meaningful error message, if it is exceeded.