### PR TITLE
Implement customizable preprocessor.

### DIFF
--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -54,10 +54,11 @@ class Project(object):
         self.extra_filetypes = settings['extra_filetypes']
         self.display = settings['display']
 
-        fpp_ext = []
-        if settings['preprocess'].lower() == 'true':
-            for ext in self.extensions:
-                if ext == ext.upper() and ext != ext.lower(): fpp_ext.append(ext)        
+        if settings['preprocess'] == 'true':
+            fpp_ext = [ext for ext in self.extensions 
+                       if ext == ext.upper() and ext != ext.lower()]
+        else:
+            fpp_ext = []
         
         self.files = []
         self.modules = []
@@ -86,12 +87,16 @@ class Project(object):
                     if item.split('.')[-1] in self.extensions and not item in settings['exclude']:
                         # Get contents of the file
                         print("Reading file {}".format(os.path.relpath(os.path.join(curdir,item))))
-                        fpp = item.split('.')[-1] in fpp_ext
+                        if item.split('.')[-1] in fpp_ext:
+                            preprocessor = settings['preprocessor']
+                        else:
+                            preprocessor = None
                         if settings['dbg']:
-                            self.files.append(ford.sourceform.FortranSourceFile(os.path.join(curdir,item),settings,fpp))
+                            self.files.append(
+                                ford.sourceform.FortranSourceFile(os.path.join(curdir,item),settings, preprocessor))
                         else:
                             try:
-                                self.files.append(ford.sourceform.FortranSourceFile(os.path.join(curdir,item),settings,fpp))
+                                self.files.append(ford.sourceform.FortranSourceFile(os.path.join(curdir,item),settings,preprocessor))
                             except Exception as e:
                                 print("Warning: Error parsing {}.\n\t{}".format(os.path.relpath(os.path.join(curdir,item)),e.args[0]))
                                 continue

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -905,7 +905,7 @@ class FortranSourceFile(FortranContainer):
     will consist of a list of these objects. In turn, SourceFile objects will
     contains lists of all of that file's contents
     """
-    def __init__(self,filepath,settings,preprocess=False):
+    def __init__(self,filepath,settings,preprocessor=None):
         self.path = filepath.strip()
         self.name = os.path.basename(self.path)
         self.settings = settings
@@ -922,7 +922,7 @@ class FortranSourceFile(FortranContainer):
                 
         source = ford.reader.FortranReader(self.path,settings['docmark'],
                     settings['predocmark'],settings['docmark_alt'],
-                    settings['predocmark_alt'],preprocess,
+                    settings['predocmark_alt'],preprocessor,
                     settings['macro'],settings['include'])
         
         FortranContainer.__init__(self,source,"")


### PR DESCRIPTION
I 've implemented a patch, which enables a customizable preprocessor. If `preprocessor` is specified in the project file, the command line specified therein is used (extended with the name of the file to process and the eventual `-D` `-I` options), otherwise it falls back to the old `gfortran -E -cpp` command line.

It also fixes the problem with Python3, that stdout/stderr from `Popen.communicate()` is a byte stream by default, which one can't pass to `StringIO`.