### PR TITLE
Reducing page rendering time

### DIFF
--- a/ford/templates/base.html
+++ b/ford/templates/base.html
@@ -31,13 +31,6 @@
     <script src="{{ project_url }}/js/jquery-2.1.3.min.js"></script>
     <script src="{{ project_url }}/js/svg-pan-zoom.min.js"></script>
 
-    {% if search|lower == 'true' %}
-    <script src="{{ project_url }}/tipuesearch/tipuesearch_content.js"></script>
-    <link  href="{{ project_url }}/tipuesearch/tipuesearch.css" rel="stylesheet">
-    <script src="{{ project_url }}/tipuesearch/tipuesearch_set.js"></script>
-    <script src="{{ project_url }}/tipuesearch/tipuesearch.js"></script>
-    {% endif %}
-
   </head>
 
   <body>
@@ -180,5 +173,13 @@
       });
     </script>
     <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    
+    {% if search|lower == 'true' %}
+    <script src="{{ project_url }}/tipuesearch/tipuesearch_content.js"></script>
+    <link  href="{{ project_url }}/tipuesearch/tipuesearch.css" rel="stylesheet">
+    <script src="{{ project_url }}/tipuesearch/tipuesearch_set.js"></script>
+    <script src="{{ project_url }}/tipuesearch/tipuesearch.js"></script>
+    {% endif %}
+    
   </body>
 </html>


### PR DESCRIPTION
For large projects the rendering of pages gets really slow. I think this is caused by a big tipuesearch_content.js file (about 70 MB for our project) which is loaded at the html head. My suggestion is to move this to the bottom, so that the rendering can take place first.