### PR TITLE
enh: reduced memory consumption and speeded up process

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -174,7 +174,7 @@ def initialize():
                 'lower':               'false',
                 'sort':                'src',
                 'extra_mods':          [],
-                'dbg':                 False,
+                'dbg':                 True,
                 'graph':               'false',
                 'license':             '',
                 'extra_filetypes':     [],

--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -124,8 +124,15 @@ class Project(object):
                             except Exception as e:
                                 print("Warning: Error parsing {}.\n\t{}".format(os.path.relpath(os.path.join(curdir,item)),e.args[0]))
                                 continue
-        self.allfiles = self.files + self.extra_files                
 
+
+    @property
+    def allfiles(self):
+        """ Instead of duplicating files, it is much more efficient to create the itterator on the fly """
+        for f in self.files:
+            yield f
+        for f in self.extra_files:
+            yield f
 
     def __str__(self):
         return self.name
@@ -148,9 +155,16 @@ class Project(object):
             non_local_mods[name.lower()] = '<a href="{}">{}</a>'.format(url,name)
         
         # Match USE statements up with the right modules
-        containers = self.modules + self.procedures + self.programs + self.submodules + self.blockdata
-        for container in containers:
-            id_mods(container,self.modules,non_local_mods,self.submodules)
+        for s in self.modules:
+            id_mods(s, self.modules, non_local_mods, self.submodules)
+        for s in self.procedures:
+            id_mods(s, self.modules, non_local_mods, self.submodules)
+        for s in self.programs:
+            id_mods(s, self.modules, non_local_mods, self.submodules)
+        for s in self.submodules:
+            id_mods(s, self.modules, non_local_mods, self.submodules)
+        for s in self.blockdata:
+            id_mods(s, self.modules, non_local_mods, self.submodules)
             
         # Get the order to process other correlations with
         deplist = {}
@@ -258,14 +272,22 @@ class Project(object):
                 for dtype in block.types:
                     self.types.append(dtype)
 
-        self.mod_lines = sum([m.num_lines for m in self.modules + self.submodules])
-        self.proc_lines = sum([p.num_lines for p in self.procedures])
-        self.file_lines = sum([f.num_lines for f in self.files])
-        self.type_lines = sum([t.num_lines for t in self.types])
-        self.type_lines_all = sum([t.num_lines_all for t in self.types])
-        self.absint_lines = sum([a.num_lines for a in self.absinterfaces])
-        self.prog_lines = sum([a.num_lines for a in self.programs])
-        self.block_lines = sum([b.num_lines for b in self.blockdata])
+        def sum_lines(*argv, **kwargs):
+            """ Wrapper for minimizing memory consumption """
+            routine = kwargs.get('func', 'num_lines')
+            n = 0
+            for arg in argv:
+                for item in arg:
+                    n += getattr(item, routine)
+            return n
+        self.mod_lines = sum_lines(self.modules, self.submodules)
+        self.proc_lines = sum_lines(self.procedures)
+        self.file_lines = sum_lines(self.files)
+        self.type_lines = sum_lines(self.types)
+        self.type_lines_all = sum_lines(self.types, func='num_lines_all')
+        self.absint_lines = sum_lines(self.absinterfaces)
+        self.prog_lines = sum_lines(self.programs)
+        self.block_lines = sum_lines(self.blockdata)
         print()
 
     def markdown(self,md,base_url='..'):
@@ -275,20 +297,17 @@ class Project(object):
         print("\nProcessing documentation comments...")
         ford.sourceform.set_base_url(base_url)        
         if self.settings['warn'].lower() == 'true': print()
-        for src in self.files + self.extra_files:
-            src.markdown(md,self)
-        return
+        for src in self.allfiles:
+            src.markdown(md, self)
 
     def make_links(self,base_url='..'):
         """
         Substitute intrasite links to documentation for other parts of 
         the program.
         """
-        
         ford.sourceform.set_base_url(base_url)        
-        for src in self.files + self.extra_files:
+        for src in self.allfiles:
             src.make_links(self)
-        return
 
 
 
@@ -321,4 +340,3 @@ def id_mods(obj,modlist,intrinsic_mods={},submodlist=[]):
         id_mods(func,modlist,intrinsic_mods)
     for subroutine in getattr(obj,'subroutines',[]):
         id_mods(subroutine,modlist,intrinsic_mods)
-    return

--- a/ford/output.py
+++ b/ford/output.py
@@ -213,30 +213,40 @@ class BasePage(object):
     Abstract class for representation of pages in the documentation.
     
       data
-        Dictionary containing project_directory
+        Dictionary containing project information (to be used when rendering)
       proj
         FortranProject object
       obj
         The object/item in the code which this page is documenting
     """    
-    def __init__(self,data,proj,obj=None):
-        self.html = self.render(data,proj,obj)
-        self.out_dir = data['output_dir']
-        self.obj = obj
+    def __init__(self,data, proj, obj=None):
         self.data = data
+        self.proj = proj
+        self.obj = obj
+
+    @property
+    def out_dir(self):
+        """ Returns the output directory of the project """
+        return self.data['output_dir']
+
+    @property
+    def html(self):
+        """ Wrapper for only doing the rendering on request (drastically reduces memory) """
+        return self.render(self.data, self.proj, self.obj)
     
     def writeout(self):
         out = open(self.outfile,'wb')
         out.write(self.html.encode('utf8'))
         out.close()
     
-    def render(self,data,proj,obj):
+    def render(self, data, proj, obj):
         """
         Get the HTML for the page. This method must be overridden. Arguments
         are proj_data, project object, and item in the code which the
         page documents.
         """
-        raise Exception("Should not instantiate BasePage type")
+        raise NotImplementedError("Should not instantiate BasePage type")
+
 
 
 class IndexPage(BasePage):

--- a/ford/output.py
+++ b/ford/output.py
@@ -75,9 +75,13 @@ class Documentation(object):
                                        self.data['coloured_edges'].lower() == 'true')
             for item in project.types:
                 self.graphs.register(item)
-            for item in project.procedures + project.submodprocedures:
+            for item in project.procedures:
                 self.graphs.register(item)
-            for item in project.modules + project.submodules:
+            for item in project.submodprocedures:
+                self.graphs.register(item)
+            for item in project.modules:
+                self.graphs.register(item)
+            for item in project.submodules:
                 self.graphs.register(item)
             for item in project.programs:
                 self.graphs.register(item)
@@ -107,9 +111,13 @@ class Documentation(object):
                 self.docs.append(TypePage(data,project,item))
             for item in project.absinterfaces:
                 self.docs.append(AbsIntPage(data,project,item))
-            for item in project.procedures + project.submodprocedures:
+            for item in project.procedures:
                 self.docs.append(ProcPage(data,project,item))
-            for item in project.modules + project.submodules:
+            for item in project.submodprocedures:
+                self.docs.append(ProcPage(data,project,item))
+            for item in project.modules:
+                self.docs.append(ModulePage(data,project,item))
+            for item in project.submodules:
                 self.docs.append(ModulePage(data,project,item))
             for item in project.programs:
                 self.docs.append(ProgPage(data,project,item))
@@ -117,9 +125,9 @@ class Documentation(object):
                 self.docs.append(BlockPage(data,project,item))
             if len(project.procedures) > 0:
                 self.lists.append(ProcList(data,project))
-            if len(project.allfiles) > 1:
+            if len(project.files) + len(project.extra_files) > 1:
                 self.lists.append(FileList(data,project))
-            if len(project.modules + project.submodules) > 0:
+            if len(project.modules) + len(project.submodules) > 0:
                 self.lists.append(ModList(data,project))
             if len(project.programs) > 1:
                 self.lists.append(ProgList(data,project))
@@ -189,8 +197,15 @@ class Documentation(object):
             shutil.copy(self.data['favicon'],os.path.join(out_dir,'favicon.png'))
         for src in self.project.allfiles:
             shutil.copy(src.path,os.path.join(out_dir,'src',src.name))
-        for p in self.docs + self.lists + self.pagetree + [self.index, self.search]:
+        # By doing this we omit a duplication of data.
+        for p in self.docs:
             p.writeout()
+        for p in self.lists:
+            p.writeout()
+        for p in self.pagetree:
+            p.writeout()
+        self.index.writeout()
+        self.search.writeout()
 
 
 class BasePage(object):

--- a/ford/output.py
+++ b/ford/output.py
@@ -219,7 +219,7 @@ class BasePage(object):
       obj
         The object/item in the code which this page is documenting
     """    
-    def __init__(self,data, proj, obj=None):
+    def __init__(self, data, proj, obj=None):
         self.data = data
         self.proj = proj
         self.obj = obj

--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -379,93 +379,100 @@ class FortranBase(object):
             else:
                 self.meta['proc_internals'] = self.meta['proc_internals'].lower()
 
-        md_list = []
+        # Create Markdown
+        for item in self.itterator('variables', 'modules', 'submodules', 'common',
+                                   'subroutines', 'modprocedures', 'functions',
+                                   'interfaces', 'absinterfaces', 'types',
+                                   'programs', 'blockdata', 'boundprocs',
+                                   'finalprocs', 'args', 'enums'):
+            if isinstance(item, FortranBase):
+                item.markdown(md, project)
+
         if hasattr(self,'variables'):
-            md_list.extend(self.variables)
-            if not isinstance(self,FortranType): sort_items(self,self.variables)
+            if not isinstance(self,FortranType):
+                sort_items(self,self.variables)
         if hasattr(self,'modules'):
-            md_list.extend(self.modules)
             sort_items(self,self.modules)
         if hasattr(self,'submodules'):
-            md_list.extend(self.submodules)
             sort_items(self,self.submodules)
         if hasattr(self,'common'):
-            md_list.extend(self.common)
             sort_items(self,self.common)
         if hasattr(self,'subroutines'):
-            md_list.extend(self.subroutines)
             sort_items(self,self.subroutines)
         if hasattr(self,'modprocedures'):
-            md_list.extend(self.modprocedures)
             sort_items(self,self.modprocedures)
         if hasattr(self,'functions'):
-            md_list.extend(self.functions)
             sort_items(self,self.functions)
         if hasattr(self,'interfaces'):
-            md_list.extend(self.interfaces)
             sort_items(self,self.interfaces)
         if hasattr(self,'absinterfaces'):
-            md_list.extend(self.absinterfaces)
             sort_items(self,self.absinterfaces)
         if hasattr(self,'types'):
-            md_list.extend(self.types)
             sort_items(self,self.types)
         if hasattr(self,'programs'):
-            md_list.extend(self.programs)
             sort_items(self,self.programs)
         if hasattr(self,'blockdata'):
-            md_list.extend(self.blockdata)
             sort_items(self,self.blockdata)
         if hasattr(self,'boundprocs'):
             # Type-bound procedures sorted at the end of correlation
             # step, once any inherited ones have been added.
-            md_list.extend(self.boundprocs)
+            pass
         if hasattr(self,'finalprocs'):
-            md_list.extend(self.finalprocs)
             sort_items(self,self.finalprocs)
         if hasattr(self,'args'):
-            md_list.extend(self.args)
             #sort_items(self.args,args=True)
-        if hasattr(self,'enums'):
-            md_list.extend(self.enums)
-        if hasattr(self,'retvar') and self.retvar: md_list.append(self.retvar)
-        if hasattr(self,'procedure'): md_list.append(self.procedure)
-
-        for item in md_list:
-            if isinstance(item, FortranBase): item.markdown(md,project)
+            pass
+        if hasattr(self,'retvar'):
+            if self.retvar:
+                if isinstance(self.retvar, FortranBase):
+                    self.retvar.markdown(md, project)
+        if hasattr(self,'procedure'):
+            if isinstance(self.procedure, FortranBase):
+                self.procedure.markdown(md, project)
 
         return
 
 
-    def make_links(self,project):
+    def make_links(self, project):
         """
         Process intra-site links to documentation of other parts of the program.
         """
         self.doc = ford.utils.sub_links(self.doc,project)
         if 'summary' in self.meta:
             self.meta['summary'] = ford.utils.sub_links(self.meta['summary'],project)
-        recurse_list = []
 
-        if hasattr(self,'variables'): recurse_list.extend(self.variables)
-        if hasattr(self,'types'): recurse_list.extend(self.types)
-        if hasattr(self,'enums'): recurse_list.extend(self.enums)
-        if hasattr(self,'modules'): recurse_list.extend(self.modules)
-        if hasattr(self,'submodules'): recurse_list.extend(self.submodules)
-        if hasattr(self,'subroutines'): recurse_list.extend(self.subroutines)
-        if hasattr(self,'functions'): recurse_list.extend(self.functions)
-        if hasattr(self,'interfaces'): recurse_list.extend(self.interfaces)
-        if hasattr(self,'absinterfaces'): recurse_list.extend(self.absinterfaces)
-        if hasattr(self,'programs'): recurse_list.extend(self.programs)
-        if hasattr(self,'boundprocs'): recurse_list.extend(self.boundprocs)
+        # Create links in the project
+        for item in self.itterator('variables', 'types', 'enums', 'modules',
+                                   'submodules', 'subroutines', 'functions',
+                                   'interfaces', 'absinterfaces', 'programs',
+                                   'boundprocs', 'args', 'bindings'):
+            if isinstance(item, FortranBase):
+                item.make_links(project)
+        if hasattr(self, 'retvar'):
+            if self.retvar:
+                if isinstance(self.retvar, FortranBase):
+                    self.retvar.make_links(project)
+        if hasattr(self, 'procedure'):
+            if isinstance(self.procedure, FortranBase):
+                self.procedure.make_links(project)
+
         # if hasattr(self,'finalprocs'): recurse_list.extend(self.finalprocs)
         # if hasattr(self,'constructor') and self.constructor: recurse_list.append(self.constructor)
-        if hasattr(self,'args'): recurse_list.extend(self.args)
-        if hasattr(self,'bindings'): recurse_list.extend(self.bindings)
-        if hasattr(self,'retvar') and self.retvar: recurse_list.append(self.retvar)
-        if hasattr(self,'procedure'): recurse_list.append(self.procedure)
 
-        for item in recurse_list:
-            if isinstance(item, FortranBase): item.make_links(project)
+    @property
+    def routines(self):
+        """ Itterator returning *both* functions and subroutines, in that order """
+        for item in self.itterator('functions', 'subroutines'):
+            yield item
+
+    def itterator(self, *argv):
+        """ Itterator returning any list of elements via attribute lookup in `self`
+
+        This itterator retains the order of the arguments """
+        for arg in argv:
+            if hasattr(self, arg):
+                for item in getattr(self, arg):
+                    yield item
 
 
 class FortranContainer(FortranBase):
@@ -773,7 +780,6 @@ class FortranContainer(FortranBase):
         raise NotImplementedError()
 
 
-
 class FortranCodeUnit(FortranContainer):
     """
     A class on which programs, modules, functions, and subroutines are based.
@@ -803,7 +809,7 @@ class FortranCodeUnit(FortranContainer):
             self.all_types.update(self.ancestor_mod.all_types)
 
         if isinstance(self,FortranSubmodule):
-            for proc in self.functions + self.subroutines:
+            for proc in self.routines:
                 if proc.module and proc.name.lower() in self.all_procs:
                     intr = self.all_procs[proc.name.lower()]
                     if intr.proctype.lower() == 'interface' and not intr.generic and not intr.abstract and intr.procedure.module == True:
@@ -920,7 +926,7 @@ class FortranCodeUnit(FortranContainer):
     def process_attribs(self):
         # IMPORTANT: Make sure types processed before interfaces--import when
         # determining permissions of derived types and overridden constructors
-        for item in self.functions + self.subroutines + self.types + self.interfaces + self.absinterfaces:
+        for item in self.itterator('functions', 'subroutines', 'types', 'interfaces', 'absinterfaces'):
             for attr in self.attr_dict.get(item.name.lower(),[]):
                 if attr == 'public' or attr == 'private' or attr == 'protected':
                     item.permission = attr
@@ -986,9 +992,9 @@ class FortranCodeUnit(FortranContainer):
         # Recurse
         for obj in self.absinterfaces:
             obj.visible = True
-        for obj in self.functions + self.subroutines + self.types + self.interfaces + getattr(self,'modprocedures',[]) + getattr(self,'modfunctions',[]) + getattr(self,'modsubroutines',[]):
+        for obj in self.itterator('functions', 'subroutines', 'types', 'interfaces', 'modprocedures', 'modfunctions', 'modsubroutines'):
             obj.visible = True
-        for obj in self.functions + self.subroutines + self.types + getattr(self,'modprocedures',[]) + getattr(self,'modfunctions',[]) + getattr(self,'modsubroutines',[]):
+        for obj in self.itterator('functions', 'subroutines', 'types', 'modprocedures', 'modfunctions', 'modsubroutines'):
             obj.prune()
 
 
@@ -1063,7 +1069,7 @@ class FortranModule(FortranCodeUnit):
         # Create list of all local procedures. Ones coming from other modules
         # will be added later, during correlation.
         self.all_procs = {}
-        for p in self.functions + self.subroutines:
+        for p in self.routines:
             self.all_procs[p.name.lower()] = p
         for interface in self.interfaces:
             if not interface.abstract:
@@ -1162,7 +1168,7 @@ class FortranSubmodule(FortranModule):
         self.process_attribs()
         self.variables = [v for v in self.variables if 'external' not in v.attribs]
         self.all_procs = {}
-        for p in self.functions + self.subroutines:
+        for p in self.routines:
             self.all_procs[p.name.lower()] = p
         for interface in self.interfaces:
             if not interface.abstract:
@@ -1236,7 +1242,7 @@ class FortranSubroutine(FortranCodeUnit):
 
     def _cleanup(self):
         self.all_procs = {}
-        for p in self.functions + self.subroutines:
+        for p in self.routines:
             self.all_procs[p.name.lower()] = p
         for interface in self.interfaces:
             if not interface.abstract:
@@ -1355,7 +1361,7 @@ class FortranFunction(FortranCodeUnit):
 
     def _cleanup(self):
         self.all_procs = {}
-        for p in self.functions + self.subroutines:
+        for p in self.routines:
             self.all_procs[p.name.lower()] = p
         for interface in self.interfaces:
             if not interface.abstract:
@@ -1424,7 +1430,7 @@ class FortranSubmoduleProcedure(FortranCodeUnit):
     def _cleanup(self):
         self.process_attribs()
         self.all_procs = {}
-        for p in self.functions + self.subroutines:
+        for p in self.routines:
             self.all_procs[p.name.lower()] = p
         for interface in self.interfaces:
             if not interface.abstract:
@@ -1455,7 +1461,7 @@ class FortranProgram(FortranCodeUnit):
 
     def _cleanup(self):
         self.all_procs = {}
-        for p in self.functions + self.subroutines:
+        for p in self.routines:
             self.all_procs[p.name.lower()] = p
         for interface in self.interfaces:
             if not interface.abstract:
@@ -1655,7 +1661,7 @@ class FortranInterface(FortranContainer):
             self.contents = contents
         elif not self.generic:
             contents = []
-            for proc in (self.functions + self.subroutines):
+            for proc in self.routines:
                 proc.visible = True
                 item = copy.copy(self)
                 item.procedure = proc

--- a/ford/templates/base.html
+++ b/ford/templates/base.html
@@ -58,7 +58,7 @@
               aria-haspopup="true"
 		 aria-expanded="false">Contents <span class="caret"></span></a>
 	      <ul class="dropdown-menu">
-              {% if project.allfiles|length > 1 %}
+              {% if project.files|length + project.extra_files|length > 1 %}
             <li><a href="{{ project_url }}/lists/files.html">Source Files</a></li>
 				{% else %}
             <li><a href="{{project.files[0].get_url()}}">Source File</a></li>
@@ -86,7 +86,7 @@
 	    {% endif %}
             </ul>
             </li>
-{% if project.allfiles|length > 1 %}
+{% if project.files|length + project.extra_files|length > 1 %}
 <li class="visible-xs hidden-sm visible-lg"><a href="{{ project_url }}/lists/files.html">Source Files</a></li>
 {% else %}
 <li class="visible-xs hidden-sm visible-lg"><a href="{{project.files[0].get_url()}}">Source File</a></li>


### PR DESCRIPTION
Quite a bit of segments around the code was using
list merges to simplify loops. However, this comes at the
price of duplicating lists while merging two lists.
This commit introduces itterators for compressing lists
while still retaining the order.

Secondly, the dbg option does not work (ford --debug)
does not accept debug. It is now True by default.

Signed-off-by: Nick Papior <nickpapior@gmail.com>