### PR TITLE
bug: fixed replacements in name conversion

### DIFF
--- a/ford/sourceform.py
+++ b/ford/sourceform.py
@@ -2403,8 +2403,9 @@ class NameSelector(object):
                 num = 1
             self._counts[item.get_dir()][item.name] = num
             name = item.name.lower().replace('<','lt')
-            name = item.name.lower().replace('>','gt')
-            name = item.name.lower().replace('/','SLASH')
+            # name is already lower
+            name = name.replace('>','gt')
+            name = name.replace('/','SLASH')
             if name == '': name = '__unnamed__'
             if num > 1:
                 name = name + '~' + str(num)


### PR DESCRIPTION
Apparently there were 3 statements of replacing content. However,
only the last statement was in use because of upper level
dependency. (item.name vs. name).
This fixes the naming scheme.

Signed-off-by: Nick Papior <nickpapior@gmail.com>