### PR TITLE
Skip subdirectories of directories listed in exclude_dir

### DIFF
--- a/ford/fortran_project.py
+++ b/ford/fortran_project.py
@@ -73,51 +73,51 @@ class Project(object):
         # Get all files within topdir, recursively
         srcdir_list = self.make_srcdir_list(settings['exclude_dir'])
         for curdir in srcdir_list:
-                for item in [ f for f in os.listdir(curdir) \
-                               if not os.path.isdir(os.path.join(curdir,f))]:
-                    ext = item.split('.')[-1]
-                    if (ext in self.extensions or ext in self.fixed_extensions) and \
-                      not item in settings['exclude']:
-                        # Get contents of the file
-                        print("Reading file {}".format(os.path.relpath(os.path.join(curdir,item))))
-                        if item.split('.')[-1] in settings['fpp_extensions']:
-                            preprocessor = settings['preprocessor']
-                        else:
-                            preprocessor = None
-                        if settings['dbg']:
-                            self.files.append(
-                                ford.sourceform.FortranSourceFile(os.path.join(curdir,item),settings, preprocessor, ext in self.fixed_extensions))
-                        else:
-                            try:
-                                self.files.append(ford.sourceform.FortranSourceFile(os.path.join(curdir,item),settings,preprocessor, ext in self.fixed_extensions))
-                            except Exception as e:
-                                print("Warning: Error parsing {}.\n\t{}".format(os.path.relpath(os.path.join(curdir,item)),e.args[0]))
-                                continue
-                        for module in self.files[-1].modules:
-                            self.modules.append(module)
-                        for submod in self.files[-1].submodules:
-                            self.submodules.append(submod)
-                        for function in self.files[-1].functions:
-                            function.visible = True
-                            self.procedures.append(function)
-                        for subroutine in self.files[-1].subroutines:
-                            subroutine.visible = True
-                            self.procedures.append(subroutine)
-                        for program in self.files[-1].programs:
-                            program.visible = True
-                            self.programs.append(program)
-                        for block in self.files[-1].blockdata:
-                            self.blockdata.append(block)
-                    elif item.split('.')[-1] in self.extra_filetypes and not item in settings['exclude']:
-                        print("Reading file {}".format(os.path.relpath(os.path.join(curdir,item))))
-                        if settings['dbg']:
+            for item in [ f for f in os.listdir(curdir) \
+                           if not os.path.isdir(os.path.join(curdir,f))]:
+                ext = item.split('.')[-1]
+                if (ext in self.extensions or ext in self.fixed_extensions) and \
+                  not item in settings['exclude']:
+                    # Get contents of the file
+                    print("Reading file {}".format(os.path.relpath(os.path.join(curdir,item))))
+                    if item.split('.')[-1] in settings['fpp_extensions']:
+                        preprocessor = settings['preprocessor']
+                    else:
+                        preprocessor = None
+                    if settings['dbg']:
+                        self.files.append(
+                            ford.sourceform.FortranSourceFile(os.path.join(curdir,item),settings, preprocessor, ext in self.fixed_extensions))
+                    else:
+                        try:
+                            self.files.append(ford.sourceform.FortranSourceFile(os.path.join(curdir,item),settings,preprocessor, ext in self.fixed_extensions))
+                        except Exception as e:
+                            print("Warning: Error parsing {}.\n\t{}".format(os.path.relpath(os.path.join(curdir,item)),e.args[0]))
+                            continue
+                    for module in self.files[-1].modules:
+                        self.modules.append(module)
+                    for submod in self.files[-1].submodules:
+                        self.submodules.append(submod)
+                    for function in self.files[-1].functions:
+                        function.visible = True
+                        self.procedures.append(function)
+                    for subroutine in self.files[-1].subroutines:
+                        subroutine.visible = True
+                        self.procedures.append(subroutine)
+                    for program in self.files[-1].programs:
+                        program.visible = True
+                        self.programs.append(program)
+                    for block in self.files[-1].blockdata:
+                        self.blockdata.append(block)
+                elif item.split('.')[-1] in self.extra_filetypes and not item in settings['exclude']:
+                    print("Reading file {}".format(os.path.relpath(os.path.join(curdir,item))))
+                    if settings['dbg']:
+                        self.extra_files.append(ford.sourceform.GenericSource(os.path.join(curdir,item),settings))
+                    else:
+                        try:
                             self.extra_files.append(ford.sourceform.GenericSource(os.path.join(curdir,item),settings))
-                        else:
-                            try:
-                                self.extra_files.append(ford.sourceform.GenericSource(os.path.join(curdir,item),settings))
-                            except Exception as e:
-                                print("Warning: Error parsing {}.\n\t{}".format(os.path.relpath(os.path.join(curdir,item)),e.args[0]))
-                                continue
+                        except Exception as e:
+                            print("Warning: Error parsing {}.\n\t{}".format(os.path.relpath(os.path.join(curdir,item)),e.args[0]))
+                            continue
         self.allfiles = self.files + self.extra_files                
 
 


### PR DESCRIPTION
This patch lets ford skip all the subdirectories of the directories
listed in exclude_dir. Right now, only directories matching exactly
those listed in exclude_dir list are skipped.

The first commit is the real one, the second simply changes the
indentation. The two have been separated to simplify the diffs.
