### PR TITLE
Added an option mathjax_config for custom setting.

### DIFF
--- a/ford/__init__.py
+++ b/ford/__init__.py
@@ -144,7 +144,7 @@ def initialize():
                'search','lower','sort','extra_mods','dbg','graph', 'license',
                'extra_filetypes','preprocessor','creation_date',
                'print_creation_date','proc_internals','coloured_edges',
-               'graph_dir','gitter_sidecar']
+               'graph_dir','gitter_sidecar','mathjax_config']
     defaults = {'src_dir':             ['./src'],
                 'extensions':          ['f90','f95','f03','f08','f15'],
                 'fpp_extensions':      ['F90','F95','F03','F08','F15','F','FOR'],
@@ -181,6 +181,7 @@ def initialize():
                 'creation_date':       '%Y-%m-%dT%H:%M:%S.%f%z',
                 'print_creation_date': False,
                 'coloured_edges':      'false',
+                'mathjax_config':      None,
                }
     listopts = ['extensions','fpp_extensions','fixed_extensions','display',
                 'extra_vartypes','src_dir','exclude','exclude_dir',

--- a/ford/output.py
+++ b/ford/output.py
@@ -43,6 +43,7 @@ from ford.graphs import graphviz_installed
 
 loc = os.path.dirname(__file__)
 env = jinja2.Environment(loader=jinja2.FileSystemLoader(os.path.join(loc, "templates")))
+env.globals['path'] = os.path # this lets us call path.* in templates
 
 class Documentation(object):
     """
@@ -189,6 +190,10 @@ class Documentation(object):
             shutil.copy(self.data['favicon'],os.path.join(out_dir,'favicon.png'))
         for src in self.project.allfiles:
             shutil.copy(src.path,os.path.join(out_dir,'src',src.name))
+        if self.data['mathjax_config'] is not None:
+          shutil.copy( self.data['mathjax_config'] ,                   \
+            os.path.join( out_dir, os.path.join( 'js/MathJax-config' , \
+            os.path.basename(self.data['mathjax_config']) ) ) )
         for p in self.docs + self.lists + self.pagetree + [self.index, self.search]:
             p.writeout()
 

--- a/ford/templates/base.html
+++ b/ford/templates/base.html
@@ -172,6 +172,9 @@
         }
       });
     </script>
+    {% if mathjax_config is not none %}
+    <script src="{{ project_url }}/js/MathJax-config/{{ path.basename(mathjax_config) }}"></script>
+    {% endif %}
     <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
     
     {% if search|lower == 'true' %}


### PR DESCRIPTION
The option mathjax_config can be used to select a javascript file with
additional MathJax settings. As described here:

https://docs.mathjax.org/en/latest/configuration.html#using-plain-javascript

it is possible to define a MathJax object which will then be used in the
initial configuration of MathJax. A typical usage could be defining
custom latex macros as described in

https://docs.mathjax.org/en/latest/tex.html#defining-tex-macros

Hence, given a file my-path/MathJax-my-latex-macros.js containing

window.MathJax = {
  TeX: {
     Macros: {
       RR: "{\\bf R}",
       bold: ["{\\bf #1}",1],
       Abs: ['\\left\\lvert #2 \\right\\rvert_{\\text{#1}}', 2, ""]
     }
   }
}

one can set

mathjax_config: my-path/MathJax-my-latex-macros.js

and use the latex macros \RR, \bold and \Abs anywhere in the ford
documentation.