### PR TITLE
Workaround to get correct relative paths.

### DIFF
--- a/ford/output.py
+++ b/ford/output.py
@@ -41,6 +41,9 @@ import ford.utils
 from ford.graphmanager import GraphManager
 from ford.graphs import graphviz_installed
 
+from ford.sourceform import FortranBase
+from ford.pagetree import PageNode
+
 loc = os.path.dirname(__file__)
 env = jinja2.Environment(loader=jinja2.FileSystemLoader(os.path.join(loc, "templates")))
 env.globals['path'] = os.path # this lets us call path.* in templates
@@ -225,9 +228,11 @@ class BasePage(object):
         The object/item in the code which this page is documenting
     """
     def __init__(self, data, proj, obj=None):
-        self.data = data
+        self.data = data.copy()
         self.proj = proj
         self.obj = obj
+        self.storeFortranBase_base_url = FortranBase.base_url
+        self.storePageNode_base_url    = PageNode.base_url
 
     @property
     def out_dir(self):
@@ -240,9 +245,17 @@ class BasePage(object):
         return self.render(self.data, self.proj, self.obj)
     
     def writeout(self):
+        tmp1 = FortranBase.base_url 
+        tmp2 = PageNode.base_url
+        FortranBase.base_url = self.storeFortranBase_base_url
+        PageNode.base_url    = self.storePageNode_base_url
+
         out = open(self.outfile,'wb')
         out.write(self.html.encode('utf8'))
         out.close()
+
+        FortranBase.base_url = tmp1
+        PageNode.base_url    = tmp2
     
     def render(self, data, proj, obj):
         """


### PR DESCRIPTION
The relatice paths in the index.html file (and possibly in the search
page) were wrong, containing ".." instead of ".". This is possibily due
to 55218855352d5458b88d3599a3dd0280d658ce43, on 2017-01-20.

The present commit introduces a workaround that works but is cumbersome
and not rebust.

The issue can be seen also in the example-project-file.md included in
ford: the links in doc/index.html which has

 <link href="../css/bootstrap.min.css" rel="stylesheet">

where it should be "./css/bootstrap.min.css" and so on.
