### PR TITLE
Re-enable graphs as table and adapt them to changed graph layout.

### DIFF
--- a/ford/css/local.css
+++ b/ford/css/local.css
@@ -212,12 +212,20 @@ table.graph {
   padding:10px;
 }
 
-.graph td.triangle:after {
+.graph td.triangle-right:after {
     content: "";
     display: block;
     border-top: 7px solid  transparent;
     border-bottom: 7px solid  transparent;
     border-left: 7px solid black;
+}
+
+.graph td.triangle-left:after {
+    content: "";
+    display: block;
+    border-top: 7px solid  transparent;
+    border-bottom: 7px solid  transparent;
+    border-right: 7px solid black;
 }
 
 .graph td.node {


### PR DESCRIPTION
4cf63d88cab97397b4b230614c6b236c97bc2a0d disabled the alternative rendering of graphs where the first hop exceeded the graph_maxnodes setting as tables. With this change those tables are generated again, and their look is changed to better resemble the corresponding graphviz visualization after the updates to the graphlayout.