### PR TITLE
Activate graph warnings if any object in the root list has warn true (#231)

### DIFF
--- a/ford/graphs.py
+++ b/ford/graphs.py
@@ -439,14 +439,13 @@ class FortranGraph(object):
                                        eval(r.meta['graph_maxdepth']))
                 self.max_nodes = max(self.max_nodes,
                                      eval(r.meta['graph_maxnodes']))
+                self.warn = self.warn or (r.settings['warn'].lower() == 'true')
         except TypeError:
             self.root.append(self.data.get_node(root))
             self.max_nesting = eval(root.meta['graph_maxdepth'])
             self.max_nodes = max(self.max_nodes,
                                  eval(root.meta['graph_maxnodes']))
             self.warn = root.settings['warn'].lower() == 'true'
-        else:
-            self.warn = next(iter(root)).settings['warn'].lower() == 'true'
         self.webdir = webdir
         if ident:
             self.ident = ident + '~~' + self.__class__.__name__


### PR DESCRIPTION
In #231 an issue was raised with empty lists for the FortranGraph. I think, the best approach to this setting is to assume warnings, if any of the root objects has warnings activated, instead of trying to get the value from the first entry in the list.
This change implements this logic and thereby should avoid issues with empty lists.